### PR TITLE
change to the new default install dir on docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a Discourse plugin to get your forums reporting performance data to [New
 Assuming you've followed the above instructions for the Discourse Docker image:
 
  1. SSH into your forum server as the user running docker (probably root)
- 2. `cd /var/docker`
+ 2. `cd /var/discourse`
  3. Open up `containers/app.yml`
  4. In the `env:` section, add `NEW_RELIC_LICENSE_KEY: <your_license_key>`
  5. In the `env:` section, add `NEW_RELIC_APP_NAME: <name_of_your_forums>`


### PR DESCRIPTION
The new recommended (and on new-install expected) path is `/var/discourse` not `/var/docker` anymore. Change this in the readme
